### PR TITLE
Itzma Unit and Integration Testing Setup

### DIFF
--- a/src/flake8_itzma.py
+++ b/src/flake8_itzma.py
@@ -1,13 +1,6 @@
 import ast
-from typing import NamedTuple
 import checks
-
-
-class Flake8ASTErrorInfo(NamedTuple):
-    line_number: int
-    offset: int
-    msg: str
-    cls: type
+from helpers import Flake8ASTErrorInfo
 
 
 class MCodingASTVisitor(ast.NodeVisitor):

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -1,0 +1,8 @@
+from typing import NamedTuple
+
+
+class Flake8ASTErrorInfo(NamedTuple):
+    line_number: int
+    offset: int
+    msg: str
+    cls: type

--- a/src/test_itzma.py
+++ b/src/test_itzma.py
@@ -1,0 +1,93 @@
+import unittest
+import testing_checks
+import helpers
+import ast
+
+
+class UnitTests(unittest.TestCase):
+    def test_error_definition(self):  # unit test 0
+        line_number, offset, msg, cls = 10, 2, "Testing Message", str
+        error = helpers.Flake8ASTErrorInfo(line_number, offset, msg, cls)
+        assert error.line_number == 10 and error.offset == 2 and error.msg == "Testing Message" and error.cls == str
+
+    def test_local_imports_not_allowed(self):  # unit test 1
+        expected = {
+            'line_number': 6,
+            'offset': 4,
+            'msg': 'IM local imports are not allowed inside a function'
+        }
+        errors = []
+        with open('test_samples/test1.py') as f:
+            code = f.read()
+        node = ast.parse(code)
+        testing_checks.LocalImportsNotAllowed.check(node, errors)
+        result = errors[0]
+        assert result.line_number == expected['line_number'] and result.offset == expected['offset'] and result.msg == expected['msg']
+
+    def test_function_name_case(self):  # unit test 2
+        expected = {
+            'line_number': 3,
+            'offset': 0,
+            'msg': 'IM function names must be camel case with lowercase first letter'
+        }
+        errors = []
+        with open('test_samples/test2.py') as f:
+            code = f.read()
+        node = ast.parse(code)
+        testing_checks.UnconventionalFunctionNamesNotAllowed.check(node, errors)
+        result = errors[0]
+        assert result.line_number == expected['line_number'] and result.offset == expected['offset'] and result.msg == expected['msg']
+
+
+    def test_class_name_case(self):  # unit test 3
+        expected = {
+            'line_number': 3,
+            'offset': 0,
+            'msg': 'IM class names must be camel case with uppercase first letter'
+        }
+        errors = []
+        with open('test_samples/test3.py') as f:
+            code = f.read()
+        node = ast.parse(code)
+        testing_checks.UnconventionalClassNamesNotAllowed.check(node, errors)
+        result = errors[0]
+        assert result.line_number == expected['line_number'] and result.offset == expected['offset'] and result.msg == expected['msg']
+
+
+    def test_variable_name_plurality(self):  # unit test 4
+        expected = {
+            'line_number': 3,
+            'offset': 0,
+            'msg': 'IM variable names must be plural if they are assigned to a list'
+        }
+        errors = []
+        with open('test_samples/test4.py') as f:
+            code = f.read()
+        node = ast.parse(code)
+        testing_checks.UnconventionalVariableNamesNotAllowed.check(node, errors)
+        result = errors[0]
+        assert result.line_number == expected['line_number'] and result.offset == expected['offset'] and result.msg == expected['msg']
+
+
+class IntegrationTests(unittest.TestCase):
+
+    def test_all_checks(self):  # integration test 1
+        expected = {
+            'line_number': 5,
+            'offset': 0,
+            'msg': 'IM function names must be camel case with lowercase first letter'
+        }
+        errors = []
+        with open('test_samples/test5.py') as f:
+            code = f.read()
+        node = ast.parse(code)
+        testing_checks.LocalImportsNotAllowed.check(node, errors)
+        testing_checks.UnconventionalFunctionNamesNotAllowed.check(node, errors)
+        testing_checks.UnconventionalClassNamesNotAllowed.check(node, errors)
+        testing_checks.UnconventionalVariableNamesNotAllowed.check(node, errors)
+        result = errors[0]
+        assert result.line_number == expected['line_number'] and result.offset == expected['offset'] and result.msg == expected['msg'] and len(errors) == 2
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/test_samples/test5.py
+++ b/src/test_samples/test5.py
@@ -1,0 +1,11 @@
+def printCat(cat):
+    print(cat)
+
+
+def Main():
+    cat = ["mojo", "jojo"]
+    printCat(cat)
+
+
+class cat:
+    name = "default"

--- a/src/testing_checks.py
+++ b/src/testing_checks.py
@@ -1,0 +1,62 @@
+import ast
+from typing import NamedTuple
+from inflection import camelize, pluralize
+
+
+class Flake8ASTErrorInfo(NamedTuple):
+    line_number: int
+    offset: int
+    msg: str
+    cls: type
+
+
+class LocalImportsNotAllowed:
+    msg = "IM local imports are not allowed inside a function"
+
+    @classmethod
+    def check(cls, node: ast.FunctionDef, errors: list[Flake8ASTErrorInfo]) -> None:
+        for child in ast.walk(node):
+            if isinstance(child, (ast.Import, ast.ImportFrom)):
+                err = Flake8ASTErrorInfo(child.lineno, child.col_offset, cls.msg, cls)
+                errors.append(err)
+
+
+class UnconventionalFunctionNamesNotAllowed:
+    msg1 = "IM function names must be camel case with lowercase first letter"
+    msg2 = "IM function names must start with a verb"
+
+    @classmethod
+    def check(cls, node: ast.FunctionDef, errors: list[Flake8ASTErrorInfo]) -> None:
+        for child in ast.walk(node):
+            if isinstance(child, ast.FunctionDef):
+                func_name = child.name
+                # camelcase check:
+                if not camelize(func_name, uppercase_first_letter=False) == func_name:
+                    err = Flake8ASTErrorInfo(child.lineno, child.col_offset, cls.msg1, cls)
+                    errors.append(err)
+
+
+class UnconventionalClassNamesNotAllowed:
+    msg = "IM class names must be camel case with uppercase first letter"
+
+    @classmethod
+    def check(cls, node: ast.ClassDef, errors: list[Flake8ASTErrorInfo]) -> None:
+        for child in ast.walk(node):
+            if isinstance(child, ast.ClassDef):
+                class_name = child.name
+                if not camelize(class_name, uppercase_first_letter=True) == class_name:
+                    err = Flake8ASTErrorInfo(child.lineno, child.col_offset, cls.msg, cls)
+                    errors.append(err)
+
+
+class UnconventionalVariableNamesNotAllowed:
+    msg = "IM variable names must be plural if they are assigned to a list"
+
+    @classmethod
+    def check(cls, node: ast.FunctionDef, errors: list[Flake8ASTErrorInfo]) -> None:
+        for child in ast.walk(node):
+            if isinstance(child, ast.Assign):  # check assignment
+                if isinstance(child.value, ast.List):  # if the value is a list
+                    if pluralize(child.targets[0].id) == child.targets[0].id:  # and the name is not plural
+                        err = Flake8ASTErrorInfo(child.lineno, child.col_offset, cls.msg, cls)
+                        errors.append(err)

--- a/src/tests/integration_tests.py
+++ b/src/tests/integration_tests.py
@@ -1,0 +1,24 @@
+from src import testing_checks
+import ast
+
+
+def test_all_checks():  # integration test 1
+    expected = {
+        'line_number': 5,
+        'offset': 0,
+        'msg': 'IM function names must be camel case with lowercase first letter'
+    }
+    errors = []
+    with open('../test_samples/test5.py') as f:
+        code = f.read()
+    node = ast.parse(code)
+    testing_checks.LocalImportsNotAllowed.check(node, errors)
+    testing_checks.UnconventionalFunctionNamesNotAllowed.check(node, errors)
+    testing_checks.UnconventionalClassNamesNotAllowed.check(node, errors)
+    testing_checks.UnconventionalVariableNamesNotAllowed.check(node, errors)
+    result = errors[0]
+    assert result.line_number == expected['line_number'] and result.offset == expected['offset'] and result.msg == \
+           expected['msg'] and len(errors) == 2
+
+
+test_all_checks()

--- a/src/tests/unit_tests.py
+++ b/src/tests/unit_tests.py
@@ -1,0 +1,78 @@
+#import sys
+#sys.path.append('../src')
+from src import testing_checks
+from src import helpers
+import ast
+
+
+def test_error_definition():  # unit test 0
+    line_number, offset, msg, cls = 10, 2, "Testing Message", str
+    error = helpers.Flake8ASTErrorInfo(line_number, offset, msg, cls)
+    assert error.line_number == 10 and error.offset == 2 and error.msg == "Testing Message" and error.cls == str
+
+
+def test_local_imports_not_allowed():  # unit test 1
+    expected = {
+        'line_number': 6,
+        'offset': 4,
+        'msg': 'IM local imports are not allowed inside a function'
+    }
+    errors = []
+    with open('../test_samples/test1.py') as f:
+        code = f.read()
+    node = ast.parse(code)
+    testing_checks.LocalImportsNotAllowed.check(node, errors)
+    result = errors[0]
+    assert result.line_number == expected['line_number'] and result.offset == expected['offset'] and result.msg == expected['msg']
+
+
+def test_function_name_case():  # unit test 2
+    expected = {
+        'line_number': 3,
+        'offset': 0,
+        'msg': 'IM function names must be camel case with lowercase first letter'
+    }
+    errors = []
+    with open('../test_samples/test2.py') as f:
+        code = f.read()
+    node = ast.parse(code)
+    testing_checks.UnconventionalFunctionNamesNotAllowed.check(node, errors)
+    result = errors[0]
+    assert result.line_number == expected['line_number'] and result.offset == expected['offset'] and result.msg == expected['msg']
+
+
+def test_class_name_case():  # unit test 3
+    expected = {
+        'line_number': 3,
+        'offset': 0,
+        'msg': 'IM class names must be camel case with uppercase first letter'
+    }
+    errors = []
+    with open('../test_samples/test3.py') as f:
+        code = f.read()
+    node = ast.parse(code)
+    testing_checks.UnconventionalClassNamesNotAllowed.check(node, errors)
+    result = errors[0]
+    assert result.line_number == expected['line_number'] and result.offset == expected['offset'] and result.msg == expected['msg']
+
+
+def test_variable_name_plurality():  # unit test 4
+    expected = {
+        'line_number': 3,
+        'offset': 0,
+        'msg': 'IM variable names must be plural if they are assigned to a list'
+    }
+    errors = []
+    with open('../test_samples/test4.py') as f:
+        code = f.read()
+    node = ast.parse(code)
+    testing_checks.UnconventionalVariableNamesNotAllowed.check(node, errors)
+    result = errors[0]
+    assert result.line_number == expected['line_number'] and result.offset == expected['offset'] and result.msg == expected['msg']
+
+
+test_error_definition()
+test_local_imports_not_allowed()
+test_function_name_case()
+test_class_name_case()
+test_variable_name_plurality()


### PR DESCRIPTION
PR Summary:
* 5 unit tests and 1 integration tests were added
* Coverage report can be obtained by running: `coverage run -m unittest test_itzma.py` and then `coverage report` 
* Coverage results: helpers.py (stmts: 6, miss: 0, cover: 100%), test_itzma.py (stmts: 60, miss: 1, cover: 98%), testing_checks.py (stmts: 47, miss: 0, cover: 100%)
* Static code analysis was obtained with pylint